### PR TITLE
Fix calendar crawler.

### DIFF
--- a/src/ly.ls
+++ b/src/ly.ls
@@ -174,7 +174,8 @@ export fetchCalendarPage = ({uri, params, page=1, last-page, seen}, done) ->
     $ = cheerio.load body
 
     results = $ 'table.news_search tbody tr' .map ->
-        [date, time, committee, summary, room] = @find 'td' .map -> @text! - /^\s*|\s*$/g
+        [date_with_time, committee, summary, room] = @find 'td' .map -> @text! - /^\s*|\s*$/g
+        [date, time] = date_with_time.match /(\d{4}-\d{2}-\d{2})[\n\t\s]+(\d{2}:\d{2}~\d{2}:\d{2})/ .slice 1
         [id] = @find 'a[href]' .map -> @attr \href .match /id=(\d+)/ .1
         {id, date, time, committee, summary, room}
 


### PR DESCRIPTION
The webpage of http://ly.g0v.tw is updated.
The columns of date and time are merged into one column.

![Screenshot](https://dchtm6r471mui.cloudfront.net/hackpad.com_iPNL16x8zdp_p.193478_1406648307399_bank.png)
